### PR TITLE
Fix ref for `npm install xx@version` installed modules for npm v2

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,12 +18,19 @@ module.exports = function npmGitInfo(package) {
   var requested = package._requested;
   var type = requested && requested.type;
 
+  // if there is a package._id property but no package._requested, this means
+  // that the dependency is installed via npm2
+  if (package._id && !requested) {
+    type = 'npm2';
+  }
+
   switch (type) {
     case 'version':
       info.ref = requested.spec;
       break;
 
     case 'tag':
+    case 'npm2':
       info.ref = package.version;
       break;
 

--- a/test/fixtures/npm-2-version.json
+++ b/test/fixtures/npm-2-version.json
@@ -1,0 +1,118 @@
+{
+  "name": "ember-data",
+  "version": "2.4.0",
+  "description": "A data layer for your Ember applications.",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/emberjs/data.git"
+  },
+  "directories": {
+    "doc": "doc",
+    "test": "tests"
+  },
+  "scripts": {
+    "build": "ember build",
+    "start": "ember server",
+    "test": "ember try:testall",
+    "node-tests": "node node-tests/nodetest-runner.js",
+    "test:optional-features": "ember test --environment=test-optional-features",
+    "bower": "bower install",
+    "production": "ember build --environment=production"
+  },
+  "engines": {
+    "node": ">= 0.10.0"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "babel-plugin-feature-flags": "^0.2.0",
+    "babel-plugin-filter-imports": "^0.2.0",
+    "broccoli-babel-transpiler": "^5.5.0",
+    "broccoli-file-creator": "^1.0.0",
+    "broccoli-merge-trees": "^1.0.0",
+    "chalk": "^1.1.1",
+    "ember-cli-babel": "^5.1.3",
+    "ember-cli-path-utils": "^1.0.0",
+    "ember-cli-string-utils": "^1.0.0",
+    "ember-cli-test-info": "^1.0.0",
+    "ember-cli-version-checker": "^1.1.4",
+    "ember-inflector": "^1.9.4",
+    "exists-sync": "0.0.3",
+    "git-repo-info": "^1.1.2",
+    "inflection": "^1.8.0",
+    "npm-git-info": "^1.0.0",
+    "semver": "^5.1.0",
+    "silent-error": "^1.0.0"
+  },
+  "devDependencies": {
+    "bower": "^1.6.5",
+    "broccoli-asset-rev": "^2.1.2",
+    "broccoli-concat": "0.0.13",
+    "broccoli-funnel": "^1.0.0",
+    "broccoli-jscs": "^1.1.0",
+    "broccoli-stew": "^1.0.1",
+    "broccoli-string-replace": "^0.1.1",
+    "broccoli-uglify-sourcemap": "^1.0.1",
+    "broccoli-yuidoc": "^2.1.0",
+    "ember-cli": "1.13.12",
+    "ember-cli-app-version": "0.5.0",
+    "ember-cli-blueprint-test-helpers": "^0.8.0",
+    "ember-cli-content-security-policy": "0.4.0",
+    "ember-cli-dependency-checker": "^1.0.1",
+    "ember-cli-htmlbars": "0.7.9",
+    "ember-cli-htmlbars-inline-precompile": "^0.2.0",
+    "ember-cli-ic-ajax": "0.2.1",
+    "ember-cli-inject-live-reload": "^1.3.1",
+    "ember-cli-internal-test-helpers": "^0.8.0",
+    "ember-cli-qunit": "^1.0.0",
+    "ember-cli-release": "0.2.3",
+    "ember-cli-uglify": "^1.2.0",
+    "ember-disable-prototype-extensions": "^1.0.0",
+    "ember-disable-proxy-controllers": "^1.0.0",
+    "ember-export-application-global": "^1.0.3",
+    "ember-publisher": "0.0.7",
+    "ember-try": "0.0.6",
+    "ember-watson": "^0.7.0",
+    "github": "^0.2.4",
+    "glob": "^5.0.13",
+    "mocha": "^2.3.4",
+    "mocha-only-detector": "0.0.2",
+    "rimraf": "^2.3.2",
+    "rsvp": "^3.1.0"
+  },
+  "peerDependencies": {
+    "ember-inflector": "^1.9.4"
+  },
+  "keywords": [
+    "ember-addon"
+  ],
+  "ember-addon": {
+    "configPath": "tests/dummy/config",
+    "paths": [
+      "lib/enable-optional-features-via-url"
+    ],
+    "after": "ember-cli-mocha"
+  },
+  "gitHead": "9f8c40927a5e8a7966c251d99eb26c3f1fb0606e",
+  "bugs": {
+    "url": "https://github.com/emberjs/data/issues"
+  },
+  "homepage": "https://github.com/emberjs/data#readme",
+  "_id": "ember-data@2.4.0",
+  "_shasum": "83def81b807dc5796634f86a26f9edadf1dbfb68",
+  "_from": "ember-data@*",
+  "_npmVersion": "2.14.10",
+  "_nodeVersion": "5.5.0",
+  "maintainers": [
+  ],
+  "dist": {
+    "shasum": "83def81b807dc5796634f86a26f9edadf1dbfb68",
+    "tarball": "http://registry.npmjs.org/ember-data/-/ember-data-2.4.0.tgz"
+  },
+  "_npmOperationalInternal": {
+    "host": "packages-6-west.internal.npmjs.com",
+    "tmp": "tmp/ember-data-2.4.0.tgz_1456793181101_0.6412536094430834"
+  },
+  "_resolved": "https://registry.npmjs.org/ember-data/-/ember-data-2.4.0.tgz",
+  "readme": "ERROR: No README data found!"
+}

--- a/test/test.js
+++ b/test/test.js
@@ -82,6 +82,22 @@ describe('npm-git-info', function() {
     expect(subject.hasVersionInRef()).to.be(true);
   });
 
+  it('should detect info from NPM v2 installed package with version', function() {
+    // this tests the result of: npm install ember-data@2.4.0, using npm v2
+    var subject = info(fixture('npm-2-version.json'));
+
+    expect(subject).to.eql({
+      name: 'ember-data',
+      version: '2.4.0',
+      sha: '9f8c40927a5e8a7966c251d99eb26c3f1fb0606e',
+      abbreviatedSha: '9f8c40927a',
+      ref: '2.4.0'
+    });
+
+    expect(subject.isInstalledAsNpmPackage()).to.be(true);
+    expect(subject.hasVersionInRef()).to.be(true);
+  });
+
   it('should detect info from NPM installed package without a version', function() {
     // this tests the result of: npm install ember-data
     var subject = info(fixture('npm-without-version.json'));


### PR DESCRIPTION
It looks like the `package.json` of a dependency installed via npm v2 has
no `package._requested`, which needs to be considered when the ref is
calculated.

---

I hope that this fixes the correct calculation for `info.ref` once and for all :pensive: I am not too familiar with the different formats of `package.json` for the different `npm` versions. Also, I am not sure if this is dependent on the `node` version too. The `package.json` in this PR is the result of using a different `npm` version which shows that there is no `package._requested` present.
